### PR TITLE
Added gordonklaus/ineffassign

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Explanation: [OSS] stands for Open-Source-Software, [PROPRIETARY] stands for pro
 * [gocyclo](https://github.com/fzipp/gocyclo) [OSS] - Calculate cyclomatic complexities of functions in Go source code
 * [Go Meta Linter](https://github.com/alecthomas/gometalinter) [OSS] - Concurrently run Go lint tools and normalise their output
 * [go vet](https://godoc.org/golang.org/x/tools/cmd/vet) [OSS] - Examines Go source code and reports suspicious constructs
+* [ineffassign](https://github.com/gordonklaus/ineffassign) - Detect ineffectual assignments in Go code
 * [safesql](https://github.com/stripe/safesql) [OSS] - Static analysis tool for Golang that protects against SQL injections 
 
 ## Groovy


### PR DESCRIPTION
This PR adds https://github.com/gordonklaus/ineffassign: Detect ineffectual assignments in Go code.

This tool is implemented in https://goreportcard.com/ where i found it.

Sadly there is no license (yet), but i created a PR for this as well: https://github.com/gordonklaus/ineffassign/pull/8