### PR TITLE
Add hopper to list of Java tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ This is a collection of static analysis tools and code quality checkers. Pull re
 * [Findbugs](https://github.com/findbugsproject/findbugs) - FindBugs is a program to find bugs in Java programs. It looks for patterns are likely to be errors.
 * [HuntBugs](https://github.com/amaembo/huntbugs) - Bytecode static analyzer tool based on Procyon Compiler Tools aimed to supersede FindBugs.
 * [OWASP Dependency Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) - Checks dependencies for known, publicly disclosed, vulnerabilities.
+* [Hopper](https://github.com/cuplv/hopper) - A static analysis tool written in scala for languages that run on JVM
 
 ## JavaScript
 


### PR DESCRIPTION
Hopper is static analysis tool for languages that run on the JVM written in scala.