### PR TITLE
add SpotBugs to Java static analyser

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This is a collection of static analysis tools and code quality checkers. Pull re
 * [Find Security Bugs](https://find-sec-bugs.github.io/) - IDE/SonarQube plugin for security audits of Java web applications.
 * [Findbugs](https://github.com/findbugsproject/findbugs) - FindBugs is a program to find bugs in Java programs. It looks for patterns are likely to be errors.
 * [HuntBugs](https://github.com/amaembo/huntbugs) - Bytecode static analyzer tool based on Procyon Compiler Tools aimed to supersede FindBugs.
+* [SpotBugs](https://spotbugs.github.io/) - SpotBugs is FindBugs' successor. A tool for static analysis to look for bugs in Java code.
 * [OWASP Dependency Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) - Checks dependencies for known, publicly disclosed, vulnerabilities.
 * [Hopper](https://github.com/cuplv/hopper) - A static analysis tool written in scala for languages that run on JVM
 


### PR DESCRIPTION
SpotBugs is FindBugs' successor.

Due to lack of official BCEL 6.1 release, it still has no stable released version. But it has already supported several build tools, [SonarQube](https://github.com/SonarQubeCommunity/sonar-findbugs) and Eclipse. SpotBugs has better Java8 support, so its release candidate version has been applied to production in several organiations.

* https://spotbugs.github.io/
