### PR TITLE
Remove ConQAT and more details about Teamscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Wrappers:
 * [SensioLabs Insight](https://insight.sensiolabs.com/) :copyright: - Detect security risks, find bugs and provide actionable metrics for PHP projects
 * [SideCI](https://sideci.com) :copyright: - An automated code reviewing tool. Improving developers' productivity.
 * [Snyk](https://snyk.io/) :copyright: - Vulnerability scanner for dependencies of node.js apps (free for Open Source Projects)
-* [Teamscale](http://www.teamscale.com/) :copyright: - analyze, monitor, and improve the quality of your code.
+* [Teamscale](http://www.teamscale.com/) :copyright: - Static and dynamic analysis tool supporting more than 25 languages and direct IDE integration. Free hosting for Open Source projects available on request. Free academic licenses available.
 * [Upsource](https://www.jetbrains.com/upsource/) :copyright: - Code review tool with static code analysis and code-aware navigation for Java, PHP, JavaScript and Kotlin.
 
 # More collections

--- a/README.md
+++ b/README.md
@@ -411,7 +411,6 @@ Wrappers:
 * [Bithound](https://www.bithound.io/) :copyright: - Code Analysis beyond Lint, specifically for Node.js.
 * [Codacy](https://www.codacy.com/) :copyright: - Code Analysis to ship Better Code, Faster.
 * [Code Climate](https://codeclimate.com/) :copyright: - The open and extensible static analysis platform, for everyone.
-* [ConQAT](http://www.conqat.org/) - a toolkit for rapid development and execution of software quality analyses.
 * [Functor Prevent](http://www.functor.se/products/prevent/) :copyright: - Static code analysis for C code.
 * [kiuwan](https://www.kiuwan.com/) :copyright: - Software Analytics in the Cloud supporting more than 22 programming languages.
 * [Landscape](https://landscape.io/) :copyright: - Static code analysis for Python


### PR DESCRIPTION
Full disclaimer: I work for CQSE, the company behind both tools.

ConQAT is no longer actively maintained by us and I wouldn't advise anyone to start using it. So I removed it from the list.

I added some more details about Teamscale. I felt that the slogan from the website didn't really tell users anything about what the tools does. Please let me know in case you don't feel that the wording is appropriate in some way.
Also, the licensing options for FOSS and academic were missing. I saw that they are mentioned for some other tools, so I added them.

Thanks for compiling the list! :-)