### PR TITLE
Add ameba - a static code analysis tool for Crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This is a collection of static analysis tools and code quality checkers. Pull re
 
 ## Crystal
 
+* [ameba](https://github.com/veelenga/ameba) - A static code analysis tool for Crystal
 * [crystal](https://crystal-lang.org/) - The Crystal compiler has built-in linting functionality.
 
 ## Elixir


### PR DESCRIPTION
Link to the repo: https://github.com/veelenga/ameba
