### PR TITLE
Add ArchUnit - a Java architecture test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This is a collection of static analysis tools and code quality checkers. Pull re
 * [Haxe Checkstyle](https://github.com/HaxeCheckstyle/haxe-checkstyle) - A static analysis tool to help developers write Haxe code that adheres to a coding standard.
 
 ## Java
+* [ArchUnit](https://www.archunit.org/) - Unit test your Java architecture
 * [Checker Framework](https://github.com/typetools/checker-framework/) - Pluggable type-checking for Java http://checkerframework.org/
 * [checkstyle](https://github.com/checkstyle/checkstyle) - checking Java source code for adherence to a Code Standard or set of validation rules (best practices)
 * [ckjm](http://www.spinellis.gr/sw/ckjm/) - calculates Chidamber and Kemerer object-oriented metrics by processing the bytecode of compiled Java files


### PR DESCRIPTION
Found it in the ThoughtWorks technology radar 2018 tool section: https://www.thoughtworks.com/radar/tools/archunit.