### PR TITLE
Update project name and URL of RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 * [pelusa](https://github.com/codegram/pelusa) - Static analysis Lint-type tool to improve your OO Ruby code
 * [quality](https://github.com/apiology/quality) - Runs quality checks on your code using community tools, and makes sure your numbers don't get any worse over time.
 * [reek](https://github.com/troessner/reek) - Code smell detector for Ruby
-* [rubocop](https://github.com/bbatsov/rubocop) - A Ruby static code analyzer, based on the community Ruby style guide.
+* [RuboCop](https://github.com/rubocop-hq/rubocop) - A Ruby static code analyzer, based on the community Ruby style guide.
 * [Rubrowser](https://github.com/blazeeboy/rubrowser) - Ruby classes interactive dependency graph generator.
 * [ruby-lint](https://github.com/YorickPeterse/ruby-lint) - Static code analysis for Ruby
 * [rubycritic](https://github.com/whitesmith/rubycritic) - A Ruby code quality reporter


### PR DESCRIPTION
Hi, this fixes inaccurate project name and GitHub URL of [RuboCop](https://github.com/rubocop-hq/rubocop).
(Recently changed to new organization: `bbatsov ` -> `rubocop-hq` )

I'm happy if you review this 😄 

Thanks.