### PR TITLE
Rename SideCI to Sider

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 * [QuantifiedCode](https://www.quantifiedcode.com/) - Automated code review & repair
 * [Scrutinizer](https://scrutinizer-ci.com/) :copyright: - A proprietery code quality checker that can be integrated with GitHub
 * [SensioLabs Insight](https://insight.sensiolabs.com/) :copyright: - Detect security risks, find bugs and provide actionable metrics for PHP projects
-* [SideCI](https://sideci.com) :copyright: - An automated code reviewing tool. Improving developers' productivity.
+* [Sider](https://sider.review) :copyright: - An automated code reviewing tool. Improving developers' productivity.
 * [Snyk](https://snyk.io/) :copyright: - Vulnerability scanner for dependencies of node.js apps (free for Open Source Projects)
 * [Teamscale](http://www.teamscale.com/) :copyright: - Static and dynamic analysis tool supporting more than 25 languages and direct IDE integration. Free hosting for Open Source projects available on request. Free academic licenses available.
 * [Upsource](https://www.jetbrains.com/upsource/) :copyright: - Code review tool with static code analysis and code-aware navigation for Java, PHP, JavaScript and Kotlin.


### PR DESCRIPTION
Hi!

Now SideCI has renamed to Sider, so this fixes name and URL of Sider.

New URL: https://sider.review/

For more details, please see [announce](https://blog.sideci.com/sideci-announcing-new-name-sider-481047359195).

Thanks.
