### PR TITLE
added link for `cargo-audit` to the Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 ## Rust
 
+* [cargo-audit](https://github.com/RustSec/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities reported to the
+[RustSec Advisory Database](https://github.com/RustSec/advisory-db/).
 * [cargo-inspect](https://github.com/mre/cargo-inspect) - Inspect Rust code without syntactic sugar to see what the compiler does behind the curtains.
 * [clippy](https://github.com/Manishearth/rust-clippy) - A code linter to catch common mistakes and improve your Rust code
 * [electrolysis](https://github.com/Kha/electrolysis) - A tool for formally verifying Rust programs by transpiling them into definitions in the Lean theorem prover.

--- a/README.md
+++ b/README.md
@@ -382,8 +382,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 ## Rust
 
-* [cargo-audit](https://github.com/RustSec/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities reported to the
-[RustSec Advisory Database](https://github.com/RustSec/advisory-db/).
+* [cargo-audit](https://github.com/RustSec/cargo-audit) - Audit Cargo.lock for crates with security vulnerabilities reported to the [RustSec Advisory Database](https://github.com/RustSec/advisory-db/).
 * [cargo-inspect](https://github.com/mre/cargo-inspect) - Inspect Rust code without syntactic sugar to see what the compiler does behind the curtains.
 * [clippy](https://github.com/Manishearth/rust-clippy) - A code linter to catch common mistakes and improve your Rust code
 * [electrolysis](https://github.com/Kha/electrolysis) - A tool for formally verifying Rust programs by transpiling them into definitions in the Lean theorem prover.


### PR DESCRIPTION
Linked to the RustSec `cargo-audit` tool within the Rust section.