### PR TITLE
Update URL for Perl::Critic

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 ## Perl
 
-* [Perl::Critic](http://search.cpan.org/~thaljef/Perl-Critic-1.126/lib/Perl/Critic.pm) - Critique Perl source code for best-practices.
+* [Perl::Critic](https://metacpan.org/pod/Perl::Critic) - Critique Perl source code for best-practices.
 
 ## PHP
 


### PR DESCRIPTION
The existing link for Perl::Critic points to an old website, and it points to a specific old version.  The new URL will always link to the latest version.