### PR TITLE
mark Tailor with warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 * [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) - A library and command-line formatting tool for reformatting Swift code
 * [SwiftLint](https://github.com/realm/SwiftLint) - A tool to enforce Swift style and conventions
-* [Tailor](https://github.com/sleekbyte/tailor) - A static analysis and lint tool for source code written in Apple's Swift programming language.
+* [Tailor](https://github.com/sleekbyte/tailor) :warning: - A static analysis and lint tool for source code written in Apple's Swift programming language.
 
 ## Tcl
 


### PR DESCRIPTION
Marking Tailor with :warning:, as it's no longer maintained. No commits since Dec 6, 2017, which is more than 2 years ago at this point.